### PR TITLE
Refactor import structure for server modules

### DIFF
--- a/app/server/AI/AskGemini.py
+++ b/app/server/AI/AskGemini.py
@@ -1,9 +1,9 @@
 import json
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional
 
 from google import genai
 
-from utilities.consts import GOOGLE_API_KEY, GeminiModelsEnum, SupportedLanguagesCodesEnum
+from ..utilities.consts import GOOGLE_API_KEY, GeminiModelsEnum, SupportedLanguagesCodesEnum
 
 
 class AskGemini:
@@ -118,7 +118,9 @@ class AskGemini:
                                  transcribed_text: str,
                                  gemini_model: GeminiModelsEnum | None = None,
                                  language: SupportedLanguagesCodesEnum = SupportedLanguagesCodesEnum.RU):
-        """Use Gemini to enhance punctuation, casing, and spacing of the transcribed text."""
+        """Use Gemini to enhance punctuation, casing, and spacing of the transcribed text.
+        Использует Gemini для улучшения пунктуации, регистра и пробелов в транскрибированном тексте.
+        """
 
         if self.client is None:
             if not GOOGLE_API_KEY:

--- a/app/server/AI/AudioToText.py
+++ b/app/server/AI/AudioToText.py
@@ -1,14 +1,14 @@
-import whisper
 import warnings
-from utilities.consts import (
-    WhisperModelsENUM,
-    SupportedLanguagesCodesEnum,
-    SupportedExtensionsEnum,
+
+import whisper
+
+from .AskGemini import AskGemini
+from ..utilities.consts import (
     GeminiModelsEnum,
-    GOOGLE_API_KEY,
+    SupportedExtensionsEnum,
+    SupportedLanguagesCodesEnum,
+    WhisperModelsENUM,
 )
-from AskGemini import AskGemini
-from google import genai
 
 
 class AudioToText:
@@ -40,7 +40,10 @@ class AudioToText:
 
     def transcribe_file(self):
         """Transcribe audio and store plain text using Whisper.
+        Преобразует аудио в текст и сохраняет его с помощью Whisper.
+
         Prefers file path input for stability/performance.
+        Предпочитает путь к файлу для стабильности и производительности.
         """
 
         if self.whisper is None:
@@ -58,7 +61,9 @@ class AudioToText:
         return self.transcribed_text
 
     def restore_transcribed_text_with_gemini(self):
-        """Use Gemini to enhance punctuation, casing, and spacing of the transcribed text."""
+        """Use Gemini to enhance punctuation, casing, and spacing of the transcribed text.
+        Использует Gemini для улучшения пунктуации, регистра и пробелов в транскрибированном тексте.
+        """
 
         gemini = AskGemini(model=self.gemini_model)
         self.transcribed_text = gemini.restore_transcribed_text(transcribed_text=self.transcribed_text, language=self.language)
@@ -74,8 +79,8 @@ class AudioToText:
 
     def _validate_init(self):
         """Validate initialization parameters.
-         Проверка параметров инициализации.
-         """
+        Проверяет параметры инициализации.
+        """
         try:
             self.language = SupportedLanguagesCodesEnum(self.language)
         except ValueError as exc:

--- a/app/server/app.py
+++ b/app/server/app.py
@@ -1,21 +1,26 @@
+import json
 import os
 import shutil
-import uuid
 import subprocess
-from pathlib import Path
-from typing import List, Any
 import time
+import uuid
+from pathlib import Path
+from typing import Any, List
 
-from fastapi import FastAPI, File, UploadFile, HTTPException, Form
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pdf2image import convert_from_path
 
-from AI.AudioToText import AudioToText
-from utilities.consts import SupportedLanguagesCodesEnum, WhisperModelsENUM, GeminiModelsEnum, ANALIZE_PDF
-from AI.AskGemini import AskGemini
-import json
+from .AI.AskGemini import AskGemini
+from .AI.AudioToText import AudioToText
+from .utilities.consts import (
+    ANALIZE_PDF,
+    GeminiModelsEnum,
+    SupportedLanguagesCodesEnum,
+    WhisperModelsENUM,
+)
 
 BASE_DIR = Path(__file__).parent.resolve()
 DATA_DIR = BASE_DIR / "data"

--- a/app/server/utilities/consts.py
+++ b/app/server/utilities/consts.py
@@ -1,6 +1,7 @@
 from enum import StrEnum
-from dotenv import load_dotenv
 import os
+
+from dotenv import load_dotenv
 
 
 load_dotenv()


### PR DESCRIPTION
## Summary
- reorder imports in server modules for PEP 8 compliance
- switch to package-relative imports for internal modules
- add missing bilingual docstrings for clarity

## Testing
- `python -m py_compile app/server/app.py app/server/AI/AskGemini.py app/server/AI/AudioToText.py app/server/utilities/consts.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc0997e620832ea13dea2d56534b93