### PR TITLE
fix: correct App component import path in tests

### DIFF
--- a/app/frontend/src/App.test.js
+++ b/app/frontend/src/App.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import App from './App';
+import App from './Components/App';
 
 test('renders learn react link', () => {
   render(<App />);


### PR DESCRIPTION
## Summary
- fix App.test.js import path to Components/App

## Testing
- `CI=true npm test` *(fails: Cannot use import statement outside a module in axios)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0cae4010832e9db921f75ae3d718